### PR TITLE
fix: configure Vite build for Chrome Extension MV3 compatibility

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="tr">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { resolve } from 'path';
 
 export default defineConfig({
     plugins: [react()],
+    // Chrome extensions load via chrome-extension://<id>/ — there is no web server,
+    // so asset paths in HTML must be relative ('./options.js') not absolute ('/options.js').
+    base: './',
     build: {
         outDir: 'dist',
         emptyOutDir: true, // Clean the output directory before each build


### PR DESCRIPTION
- Add base: './' to vite.config.ts so built HTML uses relative asset paths (./options.js) instead of absolute paths (/options.js) that break under the chrome-extension:// scheme
- Fix options.html lang attribute from 'tr' to 'en'

Closes #13